### PR TITLE
Updated max dex number for autogen sprites to 469

### DIFF
--- a/bot/utils.py
+++ b/bot/utils.py
@@ -10,7 +10,7 @@ from analysis import Analysis
 
 
 MAX_DEX_ID = 500
-MISSING_DEX_ID = 420
+MISSING_DEX_ID = 469
 
 PATTERN_ICON = r'[iI]con'
 PATTERN_CUSTOM = r'[cC]ustom'


### PR DESCRIPTION
The gitlab website is now able to display autogens for up to dex number 469. Example:
https://gitlab.com/pokemoninfinitefusion/autogen-fusion-sprites/-/raw/master/Battlers/469/469.469.png

For this reason, I suggest to increase the number. That way, fusions over 420 will not have the bot return a question mark, and will show the autogen instead.